### PR TITLE
[REFINE]: Update PM2 log rotation configuration in deployment workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,11 +103,6 @@ jobs:
               npm install -g pm2
             fi
 
-            # Configure PM2 log rotation
-            pm2 install pm2-logrotate || true
-            pm2 set pm2-logrotate:max_size 10M || true
-            pm2 set pm2-logrotate:retain 7 || true
-
             # Setup PM2 startup script
             echo "⚙️  Configuring PM2 startup..."
             PM2_STARTUP_CMD=$(pm2 startup systemd -u $USER --hp $HOME | tail -n 1)
@@ -125,7 +120,7 @@ jobs:
               --name ${{ env.APP_NAME }} \
               --cwd ${{ env.DEPLOY_PATH }} \
               --max-restarts 10 \
-              --min-uptime 10000 \
+              --min_uptime 10000 \
               --restart-delay 3000 \
               --env NODE_ENV=production \
               --env PORT=${{ secrets.PORT }} \
@@ -135,6 +130,13 @@ jobs:
               -- dist/index.js
 
             # Save PM2 process list for resurrection
+            pm2 save
+
+            # Configure PM2 log rotation (after save)
+            echo "⚙️  Configuring PM2 log rotation..."
+            pm2 install pm2-logrotate || echo "⚠️  PM2 logrotate install failed, skipping..."
+            pm2 set pm2-logrotate:max_size 10M || true
+            pm2 set pm2-logrotate:retain 7 || true
             pm2 save
 
             echo "✅ Application started"

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -102,11 +102,6 @@ jobs:
               npm install -g pm2
             fi
 
-            # Configure PM2 log rotation
-            pm2 install pm2-logrotate || true
-            pm2 set pm2-logrotate:max_size 10M || true
-            pm2 set pm2-logrotate:retain 7 || true
-
             # Setup PM2 startup script
             echo "⚙️  Configuring PM2 startup..."
             PM2_STARTUP_CMD=$(pm2 startup systemd -u $USER --hp $HOME | tail -n 1)
@@ -124,7 +119,7 @@ jobs:
               --name ${{ env.APP_NAME }} \
               --cwd ${{ env.DEPLOY_PATH }} \
               --max-restarts 10 \
-              --min-uptime 10000 \
+              --min_uptime 10000 \
               --restart-delay 3000 \
               --env NODE_ENV=development \
               --env PORT=${{ secrets.PORT }} \
@@ -134,6 +129,13 @@ jobs:
               -- dist/index.js
 
             # Save PM2 process list for resurrection
+            pm2 save
+
+            # Configure PM2 log rotation (after save)
+            echo "⚙️  Configuring PM2 log rotation..."
+            pm2 install pm2-logrotate || echo "⚠️  PM2 logrotate install failed, skipping..."
+            pm2 set pm2-logrotate:max_size 10M || true
+            pm2 set pm2-logrotate:retain 7 || true
             pm2 save
 
             echo "✅ Application started"


### PR DESCRIPTION
This pull request updates the deployment workflows for both production and development environments to improve the configuration of PM2 log rotation and fix a parameter naming issue. The main changes are reorganizing when PM2 log rotation is set up and correcting a typo in the PM2 process configuration.

**Workflow improvements:**

* Moved the PM2 log rotation configuration steps to occur after the PM2 process list is saved, ensuring log rotation settings persist across restarts. Added clearer logging and error handling for the logrotate installation. (`.github/workflows/deploy.yml`, `.github/workflows/deploy_dev.yml`) [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L106-L110) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R135-R141) [[3]](diffhunk://#diff-4c2a8d729c2f0bf33bacbd72e08ea2009e7f160045c665923cc51efa25d34007L105-L109) [[4]](diffhunk://#diff-4c2a8d729c2f0bf33bacbd72e08ea2009e7f160045c665923cc51efa25d34007R134-R140)

**Bug fix:**

* Corrected the `--min-uptime` parameter to `--min_uptime` in the PM2 process start command, matching the expected PM2 CLI option. (`.github/workflows/deploy.yml`, `.github/workflows/deploy_dev.yml`) [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L128-R123) [[2]](diffhunk://#diff-4c2a8d729c2f0bf33bacbd72e08ea2009e7f160045c665923cc51efa25d34007L127-R122)